### PR TITLE
Call method getPackage() to get the root package

### DIFF
--- a/source/class/qxl/apiviewer/dao/Package.js
+++ b/source/class/qxl/apiviewer/dao/Package.js
@@ -164,7 +164,7 @@ qx.Class.define("qxl.apiviewer.dao.Package", {
       }
       var pos = name.lastIndexOf(".");
       if (pos < 0) {
-        return qxl.apiviewer.dao.Package.__rootPackage;
+        return qxl.apiviewer.dao.Package.getPackage("");
       }
       var parentName = name.substring(0, pos);
       return qxl.apiviewer.dao.Package.getPackage(parentName, true);


### PR DESCRIPTION
The method `getParentPackage(name)` was returning the `__root` property if the class was a child of root. The `__root` property is initialized to null and if the first class is a child of root (such as `q`) then the property was returned uninitialized. This PR changes to call `getPackage("")` so it always return the root package.