### PR TITLE
Fix property method

### DIFF
--- a/source/class/qxl/apiviewer/ui/panels/MethodPanel.js
+++ b/source/class/qxl/apiviewer/ui/panels/MethodPanel.js
@@ -33,7 +33,7 @@ qx.Class.define("qxl.apiviewer.ui.panels.MethodPanel", {
      * @Override
      */
     canDisplayItem(dao) {
-      return dao instanceof qxl.apiviewer.dao.Method && !dao.isStatic();
+      return dao instanceof qxl.apiviewer.dao.Method && !dao.isStatic() || dao instanceof qxl.apiviewer.dao.PropertyMethod;
     },
   },
 });


### PR DESCRIPTION
Fixed   #10685 of qooxdoo:
```
From within the API Documentation when you click say https://qooxdoo.org/qxl.apiviewer/#qx.ui.basic.Label~setAllowShrinkY the left-hand column is grayed out, anything you click on the right-hand side remains grayed out, until you refresh, but even then when you click https://qooxdoo.org/qxl.apiviewer/#qx.ui.basic.Label~setAllowShrinkY ,~setAllowShrinkX, ~setAllowGrowX, ~setAllowGrowY, etc...
```

Property method did't belong to any panel. But property methods are marked as methods.
AFAIK property method can not be static. Am I right?